### PR TITLE
Expose Mateo's Troll Heritage

### DIFF
--- a/Sword & Sorcery/[CP] Sword & Sorcery/content.json
+++ b/Sword & Sorcery/[CP] Sword & Sorcery/content.json
@@ -72,6 +72,26 @@
                   "RemoveMail Current SnS_M_Stan_OverrideSeenToday",
                   "MarkActionApplied Current SnS.TriggerActions.OverrideSeenToday.Removal.1 false"
               ]
+          },
+
+          "SnS.TriggerActions.MateoTrollHeritage.True": {
+            "Id": "Sns.TriggerActions.MateoTrollHeritage.True",
+            "Trigger": "DayStarted",
+            "Condition": "{{MateoTrollHeritage}}",
+            "Actions": [
+              "AddMail Current SnS.Flag.MateoTrollHeritage received",
+              "MarkActionApplied Current SnS.TriggerActions.MateoTrollHeritage.False false"
+            ]
+          },
+
+          "Sns.TriggerActions.MateoTrollHeritage.False": {
+            "Id": "Sns.TriggerActions.MateoTrollHeritage.False",
+            "Trigger": "DayStarted",
+            "Condition": "!{{MateoTrollHeritage}}",
+            "Actions": [
+              "RemoveMail Current SnS.Flag.MateoTrollHeritage all",
+              "MarkActionApplied Current SnS.TriggerActions.MateoTrollHeritage.True false"
+            ]
           }
       }
   }


### PR DESCRIPTION
- Adds Trigger Actions to expose a mail flag for other mods to check when Mateo's Troll Heritage is turned on.